### PR TITLE
Disable sparse file storage in tars

### DIFF
--- a/Source/cmArchiveWrite.cxx
+++ b/Source/cmArchiveWrite.cxx
@@ -241,6 +241,10 @@ bool cmArchiveWrite::AddFile(const char* file,
   archive_entry_acl_clear(e);
   archive_entry_xattr_clear(e);
   archive_entry_set_fflags(e, 0, 0);
+
+  // Sparse files are a GNU tar extension. Do not use them.
+  archive_entry_sparse_clear(e);
+
   if(archive_write_header(this->Archive, e) != ARCHIVE_OK)
     {
     this->Error = "archive_write_header: ";


### PR DESCRIPTION
This is a simplified version of upstream commit Kitware/CMake@edae402. The format-checking parts don't cherry-pick cleanly, and non-tar formats don't support sparse files anyway, so it doesn't matter.
